### PR TITLE
Show smtp on invalid email

### DIFF
--- a/MSGViewer/pom.xml
+++ b/MSGViewer/pom.xml
@@ -111,12 +111,10 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.4</version>
         </dependency>
         <dependency>
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
-            <version>1.7</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/MSGViewer/pom.xml
+++ b/MSGViewer/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>net.sourceforge.msgviewer</groupId>
@@ -47,6 +48,12 @@
                                 </filter>
                                 <filter>
                                     <artifact>org.apache.logging.log4j:log4j-core</artifact>
+                                    <includes>
+                                        <include>**</include>
+                                    </includes>
+                                </filter>
+                                <filter>
+                                    <artifact>commons-logging:commons-logging</artifact>
                                     <includes>
                                         <include>**</include>
                                     </includes>
@@ -105,6 +112,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.4</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-validator</groupId>
+            <artifactId>commons-validator</artifactId>
+            <version>1.7</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/MSGViewer/src/main/java/net/sourceforge/MSGViewer/ViewerHelper.java
+++ b/MSGViewer/src/main/java/net/sourceforge/MSGViewer/ViewerHelper.java
@@ -14,6 +14,8 @@ import net.htmlparser.jericho.Attributes;
 import net.htmlparser.jericho.Source;
 import net.htmlparser.jericho.StartTag;
 import net.sourceforge.MSGViewer.rtfparser.ParseException;
+
+import org.apache.commons.validator.routines.EmailValidator;
 import org.apache.poi.util.IOUtils;
 
 import javax.activation.MimeType;
@@ -244,4 +246,8 @@ public class ViewerHelper {
         return new File(tmp_dir, matt.getMessage().hashCode() + ".msg");
     }
 
+    public static boolean isValidEmail(String email) {
+        EmailValidator emailValidator = EmailValidator.getInstance();
+        return emailValidator.isValid(email);
+    }
 }

--- a/MSGViewer/src/main/java/net/sourceforge/MSGViewer/ViewerPanel.java
+++ b/MSGViewer/src/main/java/net/sourceforge/MSGViewer/ViewerPanel.java
@@ -687,15 +687,7 @@ public class ViewerPanel extends javax.swing.JPanel implements HyperlinkListener
 
     private static String asMailto(RecipientEntry recipient) {
         String name = recipient.getName();
-        String email = recipient.getEmail();
-        String smtp = recipient.getSmtp();
-        String mailTo = "";
-
-        if (isNotBlank(email) && ViewerHelper.isValidEmail(email)) {
-            mailTo = email;
-        } else if (isNotBlank(smtp)) {
-            mailTo = smtp;
-        }
+        String mailTo = recipient.mailTo();
 
         if (isNotBlank(mailTo)) {
             return "<a href='mailto:" + mailTo + "'>" + (isNotBlank(name) ? name + " &lt;" + mailTo + "&gt;" : mailTo)

--- a/MSGViewer/src/main/java/net/sourceforge/MSGViewer/ViewerPanel.java
+++ b/MSGViewer/src/main/java/net/sourceforge/MSGViewer/ViewerPanel.java
@@ -642,24 +642,30 @@ public class ViewerPanel extends javax.swing.JPanel implements HyperlinkListener
 
     private void printFrom(StringBuilder sb) {
         sb.append(parent.MlM("From: "));
-        if (message.getFromEmail() == null && message.getFromName() == null) {
-        } else if (message.getFromEmail() == null) {
-            sb.append(parent.MlM("From: ")).append(message.getFromName());
-        } else if (message.getFromName() == null) {
+        String messageFromName = message.getFromName();
+        String messageFromEmail = message.getFromEmail() != null && ViewerHelper.isValidEmail(message.getFromEmail())
+                ? message.getFromEmail()
+                : message.getFromSMTPAddress();
+
+        if (messageFromEmail == null && messageFromName == null) {
+            // add nothing
+        } else if (messageFromEmail == null) {
+            sb.append(parent.MlM("From: ")).append(messageFromName);
+        } else if (messageFromName == null) {
             sb.append("<a href=\"mailto:");
-            sb.append(message.getFromEmail());
+            sb.append(messageFromEmail);
             sb.append("\">");
-            sb.append(message.getFromEmail());
+            sb.append(messageFromEmail);
         } else {
             sb.append("<a href=\"mailto:");
-            sb.append(message.getFromEmail());
+            sb.append(messageFromEmail);
             sb.append("\">");
-            sb.append(message.getFromName());
+            sb.append(messageFromName);
         }
 
-        if (message.getFromEmail() != null && ViewerHelper.isValidEmail(message.getFromEmail())) {
+        if (messageFromEmail != null && ViewerHelper.isValidEmail(messageFromEmail)) {
             sb.append(" &lt;");
-            sb.append(message.getFromEmail());
+            sb.append(messageFromEmail);
             sb.append("&gt;");
         }
 

--- a/MSGViewer/src/main/java/net/sourceforge/MSGViewer/ViewerPanel.java
+++ b/MSGViewer/src/main/java/net/sourceforge/MSGViewer/ViewerPanel.java
@@ -657,8 +657,7 @@ public class ViewerPanel extends javax.swing.JPanel implements HyperlinkListener
             sb.append(message.getFromName());
         }
 
-        if( message.getFromEmail() != null && message.getFromEmail().contains("@") )
-        {
+        if (message.getFromEmail() != null && ViewerHelper.isValidEmail(message.getFromEmail())) {
             sb.append(" &lt;");
             sb.append(message.getFromEmail());
             sb.append("&gt;");
@@ -683,8 +682,18 @@ public class ViewerPanel extends javax.swing.JPanel implements HyperlinkListener
     private static String asMailto(RecipientEntry recipient) {
         String name = recipient.getName();
         String email = recipient.getEmail();
-        if (isNotBlank(email)) {
-            return "<a href='mailto:" + email + "'>" + (isNotBlank(name) ? name + " &lt;" + email + "&gt;" : email) + "</a>";
+        String smtp = recipient.getSmtp();
+        String mailTo = "";
+
+        if (isNotBlank(email) && ViewerHelper.isValidEmail(email)) {
+            mailTo = email;
+        } else if (isNotBlank(smtp)) {
+            mailTo = smtp;
+        }
+
+        if (isNotBlank(mailTo)) {
+            return "<a href='mailto:" + mailTo + "'>" + (isNotBlank(name) ? name + " &lt;" + mailTo + "&gt;" : mailTo)
+                    + "</a>";
         }
         return name;
     }

--- a/msgparser/pom.xml
+++ b/msgparser/pom.xml
@@ -17,5 +17,10 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>commons-validator</groupId>
+            <artifactId>commons-validator</artifactId>
+            <version>1.7</version>
+        </dependency>
     </dependencies>
 </project>

--- a/msgparser/pom.xml
+++ b/msgparser/pom.xml
@@ -20,7 +20,10 @@
         <dependency>
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
-            <version>1.7</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/msgparser/src/main/java/com/auxilii/msgparser/Message.java
+++ b/msgparser/src/main/java/com/auxilii/msgparser/Message.java
@@ -149,7 +149,7 @@ public class Message {
                 if (emailValidator.isValid(email)) {
                     this.setFromSMTPAddress(email);
                 }
-                this.setFromEmail((String) property.getValue());
+                this.setFromEmail(email);
                 break;
             case PidTagSenderName:
             case PidTagSentRepresentingName:

--- a/msgparser/src/main/java/com/auxilii/msgparser/RecipientEntry.java
+++ b/msgparser/src/main/java/com/auxilii/msgparser/RecipientEntry.java
@@ -17,9 +17,14 @@
  */
 package com.auxilii.msgparser;
 
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import org.apache.commons.validator.routines.EmailValidator;
+
 /**
- * This class represents a recipient's entry of the parsed .msg file. It provides informations like the
- * email address and the display name.
+ * This class represents a recipient's entry of the parsed .msg file. It
+ * provides informations like the email address and the display name.
+ * 
  * @author thomas.misar
  * @author roman.kurmanowytsch
  */
@@ -32,7 +37,7 @@ public class RecipientEntry {
     private RecipientType type;
 
     void setProperty(Property property) {
-        switch(property.getPid()) {
+        switch (property.getPid()) {
             case PidTagRecipientType:
                 setType(RecipientType.from((int) property.getValue()));
                 break;
@@ -50,7 +55,6 @@ public class RecipientEntry {
                 break;
         }
     }
-
 
     public String getEmail() {
         return email;
@@ -90,6 +94,16 @@ public class RecipientEntry {
 
     public void setType(RecipientType type) {
         this.type = type;
+    }
+
+    public String mailTo() {
+        EmailValidator emailValidator = EmailValidator.getInstance();
+        if (isNotBlank(email) && emailValidator.isValid(email)) {
+            return email;
+        } else if (isNotBlank(smtp)) {
+            return smtp;
+        }
+        return "";
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <poi.version>3.15</poi.version>
         <log4j.version>2.13.3</log4j.version>
+        <commons-validator.version>1.7</commons-validator.version>
+        <commons-lang3.version>3.4</commons-lang3.version>
     </properties>
 
     <build>
@@ -61,6 +63,16 @@
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-core</artifactId>
                 <version>${log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-validator</groupId>
+                <artifactId>commons-validator</artifactId>
+                <version>${commons-validator.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${commons-lang3.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
I have some emails where the `PidTagSentRepresentingEmailAddress` and the `PidTagEmailAddress` are Exchange AD strings (i.e. `/o=EnchangeLabs/ou=Exchange Administrative Group...`).
The idea here is, when these fields are not valid emails, use/show the SMTP address.