### PR TITLE
Fix violations of Sonar rule 2095

### DIFF
--- a/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/.mvn/wrapper/MavenWrapperDownloader.java
@@ -106,12 +106,9 @@ public class MavenWrapperDownloader {
             });
         }
         URL website = new URL(urlString);
-        ReadableByteChannel rbc;
-        rbc = Channels.newChannel(website.openStream());
-        try (FileOutputStream fos = new FileOutputStream(destination)) {
+        try (FileOutputStream fos = new FileOutputStream(destination); 
+			ReadableByteChannel rbc = Channels.newChannel(website.openStream())) {
             fos.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
-            fos.close();
-            rbc.close();
         }
     }
 

--- a/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/.mvn/wrapper/MavenWrapperDownloader.java
@@ -108,10 +108,11 @@ public class MavenWrapperDownloader {
         URL website = new URL(urlString);
         ReadableByteChannel rbc;
         rbc = Channels.newChannel(website.openStream());
-        FileOutputStream fos = new FileOutputStream(destination);
-        fos.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
-        fos.close();
-        rbc.close();
+        try (FileOutputStream fos = new FileOutputStream(destination)) {
+            fos.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
+            fos.close();
+            rbc.close();
+        }
     }
 
 }


### PR DESCRIPTION
Hi,

This PR fixes 1 violations of [Sonar Rule 2095: 'Resources should be closed'](https://rules.sonarsource.com/java/RSPEC-2095). This is done without introducing any new violations of Sonar rules.

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 2095](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#resources-should-be-closed-sonar-rule-2095).

P.S.: Note that this PR is not created/submitted by a bot. If you have any feedback, please leave them as comments.