### PR TITLE
Fix violations of Sonar rule 2184

### DIFF
--- a/FrameWorkMinimized/src/main/java/at/redeye/FrameWork/widgets/calendar/CalendarComponent.java
+++ b/FrameWorkMinimized/src/main/java/at/redeye/FrameWork/widgets/calendar/CalendarComponent.java
@@ -338,9 +338,9 @@ public class CalendarComponent extends javax.swing.JPanel implements DisplayMont
             InfoRenderer renderer = days.get(i).getInfoRenderer();
 
             if( renderer != null )
-                renderer.setDay(cal.plusDays(count-1));
+                renderer.setDay(cal.plusDays(count- 1L));
 
-            days.get(i).setWeekDay(cal.plusDays(count-1).getDayOfWeek().getValue());
+            days.get(i).setWeekDay(cal.plusDays(count- 1L).getDayOfWeek().getValue());
         }
 
         // Samstage hervorheben
@@ -361,7 +361,7 @@ public class CalendarComponent extends javax.swing.JPanel implements DisplayMont
             InfoRenderer renderer = days.get(i).getInfoRenderer();
 
             if( renderer != null )
-                renderer.setDay(cal.plusDays(maxDays + count - 1));
+                renderer.setDay(cal.plusDays(maxDays + count - 1L ));
         }
 
         LocalDate cal2 = LocalDate.of(Year,Month,1);
@@ -380,7 +380,7 @@ public class CalendarComponent extends javax.swing.JPanel implements DisplayMont
             InfoRenderer renderer = days.get(i).getInfoRenderer();
 
             if( renderer != null )
-                renderer.setDay(cal3.plusDays(count - 1));
+                renderer.setDay(cal3.plusDays(count - 1L ));
         }
 
         jLTitle.setText( MonthNames.getFullMonthName(month)+ " " + cal.getYear());


### PR DESCRIPTION
Hi,

This PR fixes 4 violations of [Sonar Rule 2184: 'Math operands should be cast before assignment'](https://rules.sonarsource.com/java/RSPEC-2184). This is done without introducing any new violations of Sonar rules.

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 2184](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#math-operands-should-be-cast-before-assignment-sonar-rule-2184).

P.S.: Note that this PR is not created/submitted by a bot. If you have any feedback, please leave them as comments.