### PR TITLE
Adds support for OFT to EML

### DIFF
--- a/MSGViewer/src/main/java/net/sourceforge/MSGViewer/CLIHelpMSGViewer.java
+++ b/MSGViewer/src/main/java/net/sourceforge/MSGViewer/CLIHelpMSGViewer.java
@@ -25,6 +25,7 @@ public class CLIHelpMSGViewer extends CLIHelp
 
         add( new CLIOption( Msg2MBox.CLI_PARAMETER, "Converts a msg file to a mbox file.") );
         add( new CLIOption( Msg2Eml.CLI_PARAMETER, "Converts a msg file to an eml file.") );
+        add( new CLIOption( Oft2Eml.CLI_PARAMETER, "Converts an oft file to an eml file.") );
         add( new CLIOption( Eml2Msg.CLI_PARAMETER, "Converts an eml file to a msg file.") );
         add( new CLIOption( MBox2Msg.CLI_PARAMETER, "Converts a mbox file to a msg file.",
                                                     "This feature is in pre alpla state and may never will work." ) );

--- a/MSGViewer/src/main/java/net/sourceforge/MSGViewer/ModuleLauncher.java
+++ b/MSGViewer/src/main/java/net/sourceforge/MSGViewer/ModuleLauncher.java
@@ -72,6 +72,8 @@ public class ModuleLauncher extends BaseModuleLauncher {
             return new MBox2Msg(this);
         } else if (getStartupFlag(Msg2Eml.CLI_PARAMETER)) {
             return new Msg2Eml(this);
+        } else if (getStartupFlag(Oft2Eml.CLI_PARAMETER)) {
+            return new Oft2Eml(this);
         } else if (getStartupFlag(Eml2Msg.CLI_PARAMETER)) {
             return new Eml2Msg(this);
         } else {

--- a/MSGViewer/src/main/java/net/sourceforge/MSGViewer/Oft2Eml.java
+++ b/MSGViewer/src/main/java/net/sourceforge/MSGViewer/Oft2Eml.java
@@ -1,0 +1,22 @@
+/*
+ * To change this template, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package net.sourceforge.MSGViewer;
+
+/**
+ *
+ * @author martin
+ */
+public class Oft2Eml extends CLIFileConverter {
+	public static final String CLI_PARAMETER = "-oft2eml";
+
+	public Oft2Eml(ModuleLauncher module_launcher) {
+		super(module_launcher, "oft", "eml");
+	}
+
+	@Override
+	public String getCLIParameter() {
+		return CLI_PARAMETER;
+	}
+}

--- a/MSGViewer/src/main/java/net/sourceforge/MSGViewer/factory/MessageParser.java
+++ b/MSGViewer/src/main/java/net/sourceforge/MSGViewer/factory/MessageParser.java
@@ -20,6 +20,7 @@ public class MessageParser {
 
         switch (extention.toString()) {
             case "msg":
+            case "oft":
                 return parseMsgFile();
             case "mbox":
             case "eml":


### PR DESCRIPTION
OFT is very similar to MSG, I realized simply renaming files from .oft to .msg allowed MsgViewer to convert it to .eml with no issue.

Instead of needing to rename the source files each time, it would be nice to have the option within the application natively. This pull request seems to work, thanks!