### PR TITLE
Fix unicode parsing

### DIFF
--- a/MSGViewer/src/main/javacc/net/sourceforge/MSGViewer/rtfparser/RTFParser.jj
+++ b/MSGViewer/src/main/javacc/net/sourceforge/MSGViewer/rtfparser/RTFParser.jj
@@ -131,7 +131,7 @@ void unicode_char() :
 }
 {
     code = <C_UNICODE>
-    <STRING>
+    (<STRING> | <C_ESC_STRING>)
     {
         current_group.addUnicodeChar( code.image );
     }


### PR DESCRIPTION
This should fix #136 
(Too) many explanations in the issue

I'm not quite sure if this is the right way to do it, but I think it should be correct.
I have two testmails (can't publish them openly) which are now working. 

They have both kinds of RTF-Unicode Strings in them:
No. 1:
(C_UNICODE_STRING)
```
\u-3929 ?;
```

No 2:
(C_UNICODE_ESC_STRING)
```
\u8729\'b7
```