### PR TITLE
Fixed NullPointerException when attachment hasn't filename attribute

### DIFF
--- a/MSGViewer/src/main/java/net/sourceforge/MSGViewer/factory/mbox/JavaMailParser.java
+++ b/MSGViewer/src/main/java/net/sourceforge/MSGViewer/factory/mbox/JavaMailParser.java
@@ -106,7 +106,12 @@ public class JavaMailParser {
                 MimePart mpart = (MimePart) part;
 
                 FileAttachment att = new FileAttachment();
-                String filename = MimeUtility.decodeText(part.getFileName());
+                String filename = part.getFileName();
+                if (filename != null) {
+                    filename = MimeUtility.decodeText(filename);
+                } else {
+                    filename = "unknown";
+                }
                 att.setMimeTag(getMime(part.getContentType()));
                 att.setLongFilename(filename);
 


### PR DESCRIPTION
I got a NullPointerException while reading a .eml file whose Mime-Part hasn't had any filename:

```
java.lang.NullPointerException: Cannot invoke "String.contains(java.lang.CharSequence)" because "etext" is null
	at jakarta.mail.internet.MimeUtility.decodeText(MimeUtility.java:585) ~[msgviewer.jar:?]
	at net.sourceforge.MSGViewer.factory.mbox.JavaMailParser.parse(JavaMailParser.java:109) ~[msgviewer.jar:?]
	at net.sourceforge.MSGViewer.factory.mbox.JavaMailParser.parse(JavaMailParser.java:85) ~[msgviewer.jar:?]
	at net.sourceforge.MSGViewer.factory.mbox.JavaMailParser.parse(JavaMailParser.java:85) ~[msgviewer.jar:?]
	at net.sourceforge.MSGViewer.factory.mbox.JavaMailParser.parse(JavaMailParser.java:57) ~[msgviewer.jar:?]
	at net.sourceforge.MSGViewer.factory.MessageParser.parseJavaMailFile(MessageParser.java:37) ~[msgviewer.jar:?]
	at net.sourceforge.MSGViewer.factory.MessageParser.parseMessage(MessageParser.java:25) ~[msgviewer.jar:?]
```

If the filename is missing the attached commit changes it to 'unknown'.