### PR TITLE
Remove logic from MsgContainer constructor

### DIFF
--- a/MSGViewer/src/main/java/net/sourceforge/MSGViewer/factory/msg/MsgContainer.java
+++ b/MSGViewer/src/main/java/net/sourceforge/MSGViewer/factory/msg/MsgContainer.java
@@ -1,28 +1,17 @@
 package net.sourceforge.MSGViewer.factory.msg;
 
-import com.auxilii.msgparser.Message;
-import com.auxilii.msgparser.Ptyp;
-import com.auxilii.msgparser.RecipientEntry;
-import com.auxilii.msgparser.attachment.Attachment;
-import com.auxilii.msgparser.attachment.FileAttachment;
-import com.auxilii.msgparser.attachment.MsgAttachment;
-import net.sourceforge.MSGViewer.factory.msg.entries.*;
-import net.sourceforge.MSGViewer.factory.msg.properties.PropPtypInteger32;
-import net.sourceforge.MSGViewer.factory.msg.properties.PropPtypTime;
-import net.sourceforge.MSGViewer.factory.msg.properties.PropType;
-import org.apache.poi.poifs.filesystem.DirectoryEntry;
+import static com.auxilii.msgparser.Pid.*;
+import static org.apache.commons.lang3.StringUtils.*;
 
-import java.io.ByteArrayInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
+import java.io.*;
+import java.nio.*;
 import java.util.*;
 
-import static com.auxilii.msgparser.Pid.*;
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+import com.auxilii.msgparser.*;
+import com.auxilii.msgparser.attachment.*;
+import net.sourceforge.MSGViewer.factory.msg.entries.*;
+import net.sourceforge.MSGViewer.factory.msg.properties.*;
+import org.apache.poi.poifs.filesystem.*;
 
 public class MsgContainer {
     private static final String PROPERTY_STREAM = "__properties_version1.0";
@@ -33,12 +22,14 @@ public class MsgContainer {
 
     private final List<RecipientEntry> recipients = new ArrayList<>();
     private final List<Attachment> attachments = new ArrayList<>();
+    private final Message msg;
 
     MsgContainer(Message msg) {
-        parse(msg);
+        this.msg = msg;
+        parse();
     }
 
-    private void parse(Message msg) {
+    private void parse() {
         if (msg.getSubject() != null) {
             addVarEntry(new SubjectEntry(msg.getSubject()));
             addVarEntry(new StringUTF16SubstgEntry(PidTagNormalizedSubject, msg.getTopic()));

--- a/MSGViewer/src/main/java/net/sourceforge/MSGViewer/factory/msg/MsgContainer.java
+++ b/MSGViewer/src/main/java/net/sourceforge/MSGViewer/factory/msg/MsgContainer.java
@@ -35,6 +35,10 @@ public class MsgContainer {
     private final List<Attachment> attachments = new ArrayList<>();
 
     MsgContainer(Message msg) {
+        parse(msg);
+    }
+
+    private void parse(Message msg) {
         if (msg.getSubject() != null) {
             addVarEntry(new SubjectEntry(msg.getSubject()));
             addVarEntry(new StringUTF16SubstgEntry(PidTagNormalizedSubject, msg.getTopic()));

--- a/MSGViewer/src/main/java/net/sourceforge/MSGViewer/factory/msg/MsgContainer.java
+++ b/MSGViewer/src/main/java/net/sourceforge/MSGViewer/factory/msg/MsgContainer.java
@@ -39,6 +39,12 @@ public class MsgContainer {
         this.msg = msg;
     }
 
+    /**
+     * Write header and properties of the message to the given filesystem.
+     * See [MS-OXMSG] §2.4 for details about the message structure.
+     *
+     * @param root the root of the filesystem.
+     */
     public void write(DirectoryEntry root) throws IOException {
         parse();
         int headerSize = root.getParent() == null ? 32 : 24;

--- a/MSGViewer/src/test/java/net/sourceforge/MSGViewer/factory/msg/MsgContainerTest.java
+++ b/MSGViewer/src/test/java/net/sourceforge/MSGViewer/factory/msg/MsgContainerTest.java
@@ -1,0 +1,33 @@
+package net.sourceforge.MSGViewer.factory.msg;
+
+import com.auxilii.msgparser.Message;
+import org.apache.poi.poifs.filesystem.DirectoryNode;
+import org.apache.poi.poifs.filesystem.POIFSFileSystem;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MsgContainerTest {
+
+    @Test
+    void should_convert_message_to_POI_Filesystem() throws IOException {
+        Message msg = new Message();
+
+        try (POIFSFileSystem fs = new POIFSFileSystem()) {
+            DirectoryNode root = fs.getRoot();
+
+            MsgContainer cont = new MsgContainer(msg);
+            cont.write(root);
+
+            assertThat(root.getEntryNames()).containsExactlyInAnyOrder(
+                    "__substg1.0_0C1E001F",
+                    "__nameid_version1.0",
+                    "__substg1.0_001A001F",
+                    "__substg1.0_0064001F",
+                    "__properties_version1.0"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Move logic from the constructor to the write method to make the conversion lazy