### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -1,4 +1,6 @@
 name: Qodana
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/lolo101/MsgViewer/security/code-scanning/4](https://github.com/lolo101/MsgViewer/security/code-scanning/4)

In general, the fix is to explicitly declare a minimal `permissions` block for the workflow or for the specific job so that the `GITHUB_TOKEN` is limited to only what this workflow needs. Since this workflow appears to only check out code and run Qodana (a static analysis tool) without modifying the repository, `contents: read` is a suitable minimal set of permissions.

The best fix without changing functionality is to add a top-level `permissions:` block, just below the `name:` line and above `on:` in `.github/workflows/code_quality.yml`. This will apply to all jobs in the workflow (currently just `qodana`) and ensure that the `GITHUB_TOKEN` only has read access to repository contents. No imports or other definitions are needed, since this is purely a YAML configuration change for GitHub Actions.

Specifically, in `.github/workflows/code_quality.yml`, insert:

```yaml
permissions:
  contents: read
```

between line 1 (`name: Qodana`) and line 2 (`on:`). No other changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
