### PR TITLE
Fix #439 temporary file is named by their hashed content

### DIFF
--- a/MSGViewer/src/main/java/net/sourceforge/MSGViewer/AttachmentRepository.java
+++ b/MSGViewer/src/main/java/net/sourceforge/MSGViewer/AttachmentRepository.java
@@ -5,16 +5,26 @@ import com.auxilii.msgparser.attachment.FileAttachment;
 import com.auxilii.msgparser.attachment.MsgAttachment;
 
 import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
 
 public class AttachmentRepository {
     private final Root root;
+    private final MessageDigest digest;
 
     public AttachmentRepository(Root root) {
         this.root = root;
+        try {
+            digest = MessageDigest.getInstance("SHA-1");
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public Path getTempFile(FileAttachment fatt) {
-        return getTempFile(fatt.getContentId() + fatt.getExtension());
+        String tempFileName = HexFormat.of().formatHex(digest.digest(fatt.getData()));
+        return getTempFile(tempFileName);
     }
 
     public Path getTempFile(MsgAttachment matt) {

--- a/MSGViewer/src/test/java/net/sourceforge/MSGViewer/AttachmentRepositoryTest.java
+++ b/MSGViewer/src/test/java/net/sourceforge/MSGViewer/AttachmentRepositoryTest.java
@@ -6,24 +6,33 @@ import com.auxilii.msgparser.attachment.FileAttachment;
 import com.auxilii.msgparser.attachment.MsgAttachment;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class AttachmentRepositoryTest {
     @Test
-    void should_name_file_with_attachment_content_id_and_extension() {
-        String contentId = "content-id";
-
+    void should_name_file_with_data_hash() {
         Root root = new Root("test");
         AttachmentRepository attachmentRepository = new AttachmentRepository(root);
         FileAttachment fileAttachment = new FileAttachment();
-        fileAttachment.setContentId(contentId);
-        fileAttachment.setFilename("toto.txt");
+        fileAttachment.setData("Coucou les gars !".getBytes(StandardCharsets.UTF_8));
 
         Path tempFile = attachmentRepository.getTempFile(fileAttachment);
 
-        assertEquals(contentId + ".txt", tempFile.getFileName().toString());
+        assertEquals("0de1997f0708e76553b03d40ff8420e351add892", tempFile.getFileName().toString());
+    }
+
+    @Test
+    void should_name_empty_file_with_empty_data_hash() {
+        Root root = new Root("test");
+        AttachmentRepository attachmentRepository = new AttachmentRepository(root);
+        FileAttachment fileAttachment = new FileAttachment();
+
+        Path tempFile = attachmentRepository.getTempFile(fileAttachment);
+
+        assertEquals("da39a3ee5e6b4b0d3255bfef95601890afd80709", tempFile.getFileName().toString());
     }
 
     @Test

--- a/msgparser/src/main/java/com/auxilii/msgparser/attachment/FileAttachment.java
+++ b/msgparser/src/main/java/com/auxilii/msgparser/attachment/FileAttachment.java
@@ -52,7 +52,7 @@ public class FileAttachment implements Attachment {
     /**
      * The attachment itself as a byte array.
      */
-    private byte[] data;
+    private byte[] data = new byte[0];
 
     /**
      * AttachContentId


### PR DESCRIPTION
Temp file attachments are named by their hashed content

- multiples files with identical content are stored as a single temp file
- files with identical name but different contents are stored as separate temp files